### PR TITLE
link naar fb page ipv naar profiel

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@ keywords:
   - secundair onderwijs
 
 links:
-  social-fb: https://www.facebook.com/fabienne.segaert
+  social-fb: https://www.facebook.com/LetsTalkTaalcoaching
   social-tw: https://twitter.com/fabiennesegaert
   social-in: https://www.linkedin.com/in/fabiennesegaert
   mail: fabienne@lets-talk-taalcoaching.be


### PR DESCRIPTION
Fabienne, 

fb page zo aangepast dat de link nu netjes er zo uitziet: https://www.facebook.com/LetsTalkTaalcoaching
In deze aanpassing gebruik ik die link ook voor je fb-clipje

Niet vergeten mergen...
-marc=
